### PR TITLE
Bugfix - Verbose implementation

### DIFF
--- a/SecretManagement.KeePass.Extension/SecretManagement.KeePass.Extension.psm1
+++ b/SecretManagement.KeePass.Extension/SecretManagement.KeePass.Extension.psm1
@@ -124,7 +124,7 @@ function Test-SecretVault {
         $VerbosePreference = "Continue"
     }
     $ErrorActionPreference = 'Stop'
-    Write-Verbose "SecretManagement: Testing Vault ${VaultName}" 
+    Write-Verbose "SecretManagement: Testing Vault ${VaultName}"
 
     if (-not $VaultName) { throw 'Keepass: You must specify a Vault Name to test' }
 
@@ -139,7 +139,7 @@ function Test-SecretVault {
 
     try {
         $VaultMasterKey = (Get-Variable -Name "Vault_$VaultName" -Scope Script -ErrorAction Stop).Value
-        Write-Verbose "Vault ${VaultName}: Master Key found in Cache, skipping user prompt" 
+        Write-Verbose "Vault ${VaultName}: Master Key found in Cache, skipping user prompt"
     } catch {
         $GetCredentialParams = @{
             Username = 'VaultMasterKey'
@@ -152,7 +152,7 @@ function Test-SecretVault {
     
     if (-not (Get-KeePassDatabaseConfiguration -DatabaseProfileName $VaultName)) {
         New-KeePassDatabaseConfiguration -DatabaseProfileName $VaultName -DatabasePath $AdditionalParameters.Path -UseMasterKey
-        Write-Verbose "Vault ${VaultName}: A PoshKeePass database configuration was not found but was created." 
+        Write-Verbose "Vault ${VaultName}: A PoshKeePass database configuration was not found but was created."
         return $true
     }
     try {

--- a/SecretManagement.KeePass.Extension/SecretManagement.KeePass.Extension.psm1
+++ b/SecretManagement.KeePass.Extension/SecretManagement.KeePass.Extension.psm1
@@ -120,8 +120,10 @@ function Test-SecretVault {
     )
 
     $VaultParameters = $AdditionalParameters
+    # $AdditionalParameters.Verbose can be $null on older version, hence why the -eq $true
+    $VerboseFlag = @{Verbose = $VaultParameters.Verbose -eq $true }
     $ErrorActionPreference = 'Stop'
-    Write-Verbose "SecretManagement: Testing Vault ${VaultName}"
+    Write-Verbose "SecretManagement: Testing Vault ${VaultName}" @VerboseFlag
 
     if (-not $VaultName) { throw 'Keepass: You must specify a Vault Name to test' }
 
@@ -136,7 +138,7 @@ function Test-SecretVault {
 
     try {
         $VaultMasterKey = (Get-Variable -Name "Vault_$VaultName" -Scope Script -ErrorAction Stop).Value
-        Write-Verbose "Vault ${VaultName}: Master Key found in Cache, skipping user prompt"
+        Write-Verbose "Vault ${VaultName}: Master Key found in Cache, skipping user prompt" @VerboseFlag
     } catch {
         $GetCredentialParams = @{
             Username = 'VaultMasterKey'
@@ -149,7 +151,7 @@ function Test-SecretVault {
     
     if (-not (Get-KeePassDatabaseConfiguration -DatabaseProfileName $VaultName)) {
         New-KeePassDatabaseConfiguration -DatabaseProfileName $VaultName -DatabasePath $AdditionalParameters.Path -UseMasterKey
-        Write-Verbose "Vault ${VaultName}: A PoshKeePass database configuration was not found but was created."
+        Write-Verbose "Vault ${VaultName}: A PoshKeePass database configuration was not found but was created." @VerboseFlag
         return $true
     }
     try {

--- a/SecretManagement.KeePass.Extension/SecretManagement.KeePass.Extension.psm1
+++ b/SecretManagement.KeePass.Extension/SecretManagement.KeePass.Extension.psm1
@@ -120,10 +120,11 @@ function Test-SecretVault {
     )
 
     $VaultParameters = $AdditionalParameters
-    # $AdditionalParameters.Verbose can be $null on older version, hence why the -eq $true
-    $VerboseFlag = @{Verbose = $VaultParameters.Verbose -eq $true }
+    if ($VaultParameters.Verbose) {
+        $VerbosePreference = "Continue"
+    }
     $ErrorActionPreference = 'Stop'
-    Write-Verbose "SecretManagement: Testing Vault ${VaultName}" @VerboseFlag
+    Write-Verbose "SecretManagement: Testing Vault ${VaultName}" 
 
     if (-not $VaultName) { throw 'Keepass: You must specify a Vault Name to test' }
 
@@ -138,7 +139,7 @@ function Test-SecretVault {
 
     try {
         $VaultMasterKey = (Get-Variable -Name "Vault_$VaultName" -Scope Script -ErrorAction Stop).Value
-        Write-Verbose "Vault ${VaultName}: Master Key found in Cache, skipping user prompt" @VerboseFlag
+        Write-Verbose "Vault ${VaultName}: Master Key found in Cache, skipping user prompt" 
     } catch {
         $GetCredentialParams = @{
             Username = 'VaultMasterKey'
@@ -151,7 +152,7 @@ function Test-SecretVault {
     
     if (-not (Get-KeePassDatabaseConfiguration -DatabaseProfileName $VaultName)) {
         New-KeePassDatabaseConfiguration -DatabaseProfileName $VaultName -DatabasePath $AdditionalParameters.Path -UseMasterKey
-        Write-Verbose "Vault ${VaultName}: A PoshKeePass database configuration was not found but was created." @VerboseFlag
+        Write-Verbose "Vault ${VaultName}: A PoshKeePass database configuration was not found but was created." 
         return $true
     }
     try {


### PR DESCRIPTION
`Write-Verbose` didn't work properly with SecretManagement implemented module.
It has now been fixed : https://github.com/PowerShell/SecretManagement/issues/66

That being said, to use it, it need to be obtained from `$AdditionalParameters.Verbose`