### PR TITLE
Feature Request: Recycle Bin Visibility and Full Path Toggle VaultParameters

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,5 +36,12 @@ This is a simple proof-of-concept using a modified version of PoshKeePass to all
     Get-Secret -Name 'My secret entry 1' -VaultName 'testVault'
     ```
 
+# Vault Parameters
+- `Path`: Path to your keepass database
+- `KeyPath`: Path to your keepass keyfile, if required for your vault
+- `UseWindowsAccount`: Set to true if your vault is locked with your windows Account
+- `ShowFullPath`: Set to `$true` to display the full path of secret keys. Useful if you have keys with duplicate names in multiple
+- `ShowRecyleBin`: Set to `$true` to have deleted recycle bin entries included in the results.
+
 [Actions]: https://github.com/JustinGrote/SecretManagement.KeePass/workflows/Test/badge.svg?branch=main
 [ActionsLink]: https://github.com/JustinGrote/SecretManagement.KeePass/workflows

--- a/SecretManagement.KeePass.Extension/Public/Get-Secret.ps1
+++ b/SecretManagement.KeePass.Extension/Public/Get-Secret.ps1
@@ -5,6 +5,7 @@ function Get-Secret {
         [hashtable]$AdditionalParameters = (Get-SecretVault -Name $VaultName).VaultParameters
     )
     $ErrorActionPreference = 'Stop'
+    if (-not $Name) {write-warning "You must specify a secret Name";throw}
     if (-not (Test-SecretVault -VaultName $vaultName)) {throw "Vault ${VaultName}: Not a valid vault configuration"}
     $KeepassParams = GetKeepassParams $VaultName $AdditionalParameters
 

--- a/SecretManagement.KeePass.Extension/Public/Get-Secret.ps1
+++ b/SecretManagement.KeePass.Extension/Public/Get-Secret.ps1
@@ -9,7 +9,8 @@ function Get-Secret {
     $KeepassParams = GetKeepassParams $VaultName $AdditionalParameters
 
     if ($Name) { $KeePassParams.Title = $Name }
-    $keepassGetResult = Get-KPEntry @KeepassParams | ConvertTo-KPPSObject | Where-Object ParentGroup -NotMatch 'RecycleBin'
+    $keepassGetResult = Get-SecretInfo -Vault $vaultName -Filter $Name -AsKPPSObject
+
     if ($keepassGetResult.count -gt 1) { throw "Multiple ambiguous entries found for $Name, please remove the duplicate entry" }
     $result = if (-not $keepassGetResult.Username) {
         $keepassGetResult.Password

--- a/SecretManagement.KeePass.Extension/Public/Get-SecretInfo.ps1
+++ b/SecretManagement.KeePass.Extension/Public/Get-SecretInfo.ps1
@@ -11,7 +11,7 @@ function Get-SecretInfo {
     $KeepassParams = GetKeepassParams -VaultName $VaultName -AdditionalParameters $AdditionalParameters
     $KeepassGetResult = Get-KPEntry @KeepassParams | ConvertTo-KPPSObject
     if (-not $AdditionalParameters.ShowRecycleBin) {
-        $KeepassGetResult = $KeepassGetResult | Where-Object FullPath -notmatch '^.+?/Recycle Bin'
+        $KeepassGetResult = $KeepassGetResult | Where-Object FullPath -notmatch '^[^/]+?/RecycleBin$'
     }
 
     #TODO: Split this off into private function for testing

--- a/SecretManagement.KeePass.Extension/Public/Get-SecretInfo.ps1
+++ b/SecretManagement.KeePass.Extension/Public/Get-SecretInfo.ps1
@@ -1,30 +1,74 @@
+using namespace Microsoft.PowerShell.SecretManagement
 function Get-SecretInfo {
     param(
         [string]$Filter,
         [string]$VaultName = (Get-SecretVault).VaultName,
-        [hashtable]$AdditionalParameters = (Get-SecretVault -Name $VaultName).VaultParameters
+        [hashtable]$AdditionalParameters = (Get-SecretVault -Name $VaultName).VaultParameters,
+        [Switch]$AsKPPSObject
     )
     if (-not (Test-SecretVault -VaultName $vaultName)) {throw "Vault ${VaultName}: Not a valid vault configuration"}
 
     $KeepassParams = GetKeepassParams -VaultName $VaultName -AdditionalParameters $AdditionalParameters
-    $KeepassGetResult = Get-KPEntry @KeepassParams | 
-        ConvertTo-KPPSObject |
-        Where-Object {$_ -notmatch '^.+?/Recycle Bin/'}
+    $KeepassGetResult = Get-KPEntry @KeepassParams | ConvertTo-KPPSObject
+    if (-not $AdditionalParameters.ShowRecycleBin) {
+        $KeepassGetResult = $KeepassGetResult | Where-Object FullPath -notmatch '^.+?/Recycle Bin'
+    }
 
-    [Object[]]$secretInfoResult = $KeepassGetResult | Where-Object Title -like $Filter | Foreach-Object {
+    #TODO: Split this off into private function for testing
+    function Get-KPSecretName ([PSCustomObject]$KPPSObject) {
+        <#
+        .SYNOPSIS
+        Gets the secret name for the vault context, contingent on some parameters
+        WARNING: Relies on external context $AdditionalParameters
+        #>
+        if ($AdditionalParameters.ShowFullPath) {
+            #Strip everything before the first /
+            $i = $KPPSObject.FullPath.IndexOf('/')
+            $prefix = if ($i -eq -1) {$null} else {
+                $KPPSObject.FullPath.Substring($i+1)
+            }
+            #Output Prefix/Title
+            if ($prefix) {
+                return $prefix,$KPPSObject.Title -join '/'
+            } else {
+                return $KPPSObject.Title
+            }
+        } else {
+            return $KPPSObject.Title
+        }
+    }
+
+    if ($Filter) {
+        $KeepassGetResult = $KeepassGetResult | Where-Object {
+            (Get-KPSecretName $PSItem) -like $Filter
+        } 
+    }
+
+    #Used by internal commands like Get-Secret
+    if ($AsKPPSObject) {
+        return $KeepassGetResult
+    }
+
+    [Object[]]$secretInfoResult = $KeepassGetResult | Foreach-Object {
+        if (-not $PSItem.Title) {
+            Write-Warning "Keepass Entry with blank title found at $($PSItem.FullPath). These are not currently supported and will be omitted"
+            return
+        }
+
         #TODO: Find out why the fully qualified is required on Linux even though using Namespace is defined above
         [Microsoft.PowerShell.SecretManagement.SecretInformation]::new(
-            $PSItem.Title, #string name
+            (Get-KPSecretName $PSItem), #string name
+            #TODO: Add logic to mark as securestring if there is no username
             [Microsoft.PowerShell.SecretManagement.SecretType]::PSCredential, #SecretType type
             $VaultName #string vaultName
         )
     }
 
-    [Object[]]$sortedInfoResult = $secretInfoResult | Sort-Object -Unique Name
+    [Object[]]$sortedInfoResult = $secretInfoResult | Sort-Object -Unique -Property Name
     if ($sortedInfoResult.count -lt $secretInfoResult.count) {
-        $filteredRecords = (Compare-Object $sortedInfoResult $secretInfoResult | Where-Object SideIndicator -eq '=>').InputObject
-        Write-Warning "Vault ${VaultName}: Entries with non-unique titles were detected, the duplicates were filtered out. Duplicate titles are currently not supported with this extension, ensure your entry titles are unique in the database."
-        Write-Warning "Vault ${VaultName}: Filtered Non-Unique Titles: $($filteredRecords -join ', ')"
+        $nonUniqueFilteredRecords = Compare-Object $sortedInfoResult $secretInfoResult -Property Name | Where-Object SideIndicator -eq '=>'
+        Write-Warning "Vault ${VaultName}: Entries with non-unique titles were detected, the duplicates were filtered out. $(if (-not $additionalParameters.ShowFullPath) {'Consider adding the ShowFullPath VaultParameter to your vault registration'})"
+        Write-Warning "Vault ${VaultName}: Filtered Non-Unique Titles: $($nonUniqueFilteredRecords.Name -join ', ')"
     }
     $sortedInfoResult
 }

--- a/SecretManagement.KeePass.Extension/Public/Remove-Secret.ps1
+++ b/SecretManagement.KeePass.Extension/Public/Remove-Secret.ps1
@@ -7,8 +7,9 @@ function Remove-Secret {
     if (-not (Test-SecretVault -VaultName $vaultName)) {throw "Vault ${VaultName}: Not a valid vault configuration"}
     $KeepassParams = GetKeepassParams $VaultName $AdditionalParameters
 
-    $GetKeePassResult = Get-KPEntry @KeepassParams -Title $Name
+    $GetKeePassResult = Get-SecretInfo -VaultName $VaultName -Title $Name -AsKPPSObject
+    if ($GetKeePassResult.count -gt 1) {throw "Get-SecretInfo returned an ambiguous result for Remove-Secret and it should not do that"}
     if (-not $GetKeePassResult) { throw "No Keepass Entry named $Name found" }
-    Remove-KPEntry @KeepassParams -KeePassEntry $GetKeePassResult -ErrorAction stop -Confirm:$false
+    Remove-KPEntry @KeepassParams -KeePassEntry $GetKeePassResult.KPEntry -ErrorAction stop -Confirm:$false
     return $true
 }

--- a/SecretManagement.KeePass.Extension/Public/Set-Secret.ps1
+++ b/SecretManagement.KeePass.Extension/Public/Set-Secret.ps1
@@ -12,6 +12,7 @@ function Set-Secret {
     $KeepassParams = GetKeepassParams $VaultName $AdditionalParameters
 
     #Set default group
+    #TODO: Support Creating Secrets with paths
     $KeepassParams.KeePassGroup = (Get-Variable "VAULT_$VaultName").Value.RootGroup
 
     switch ($Secret.GetType()) {

--- a/SecretManagement.KeePass.Extension/Public/Test-SecretVault.ps1
+++ b/SecretManagement.KeePass.Extension/Public/Test-SecretVault.ps1
@@ -13,6 +13,7 @@ function Test-SecretVault {
         $VerbosePreference = $true
     }
     Write-Verbose "SecretManagement: Testing Vault ${VaultName}"
+    #TODO: Hash vault parameter settings and reset vault state if they change. May be a bug if user changes vault parameters in same session
 
     #Test if connection already open, no need to do further testing if so
     try {


### PR DESCRIPTION
Adds `ShowRecycleBin` parameter (off by default) to show entries in the recycle bin
Also adds `ShowFullPath` parameter (off by default) to use full paths for KeePass entries, in case you want duplicate titled-entries in multiple folders
Implements #9
Implements #10 