### PR TITLE
Update parameter names in README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,7 @@ This is a simple proof-of-concept using a modified version of PoshKeePass to all
 2. Get the secret data using Get-Secret
 
     ```powershell
-    Get-Secret -Name 'My secret entry 1' -VaultName 'testVault'
+    Get-Secret -Name 'My secret entry 1' -Vault 'testVault'
     ```
 
 ## Known Limitations

--- a/README.MD
+++ b/README.MD
@@ -27,7 +27,7 @@ This is a simple proof-of-concept using a modified version of PoshKeePass to all
 1. (optional) Use Test-SecretVault to validate your connection to the vault
 
     ```powershell
-    Test-SecretVault -Vault 'testVault'
+    Test-SecretVault -Name 'testVault'
     ```
 
 2. Get the secret data using Get-Secret


### PR DESCRIPTION
This is a simple PR to update two parameter names in README.MD. 🙂

I found this while using Microsoft.PowerShell.SecretManagement version 1.0.0 and SecretManagement.KeePass version 0.9.2.